### PR TITLE
Pre-cache the DB similarity matrix for DBScheduler

### DIFF
--- a/tensor2struct/training/data_scheduler.py
+++ b/tensor2struct/training/data_scheduler.py
@@ -5,6 +5,7 @@ import torch
 import itertools
 import logging
 import abc
+from collections import deepcopy
 
 from tensor2struct.utils import registry
 from tensor2struct.training import spider_eval
@@ -125,7 +126,7 @@ class DBScheduler(DataScheduler):
         dbs = self.db_list
         db_sim = {}
         for db1 in dbs:
-            other_dbs = self.deepcopy(self.db_list)
+            other_dbs = deepcopy(self.db_list)
             other_dbs.remove(db1)
             db1_ = db1.replace("_", " ")
             db1_sim = {}


### PR DESCRIPTION
Hi Bailin,

I've implemented a caching approach for the database similarity matrix when using DBScheduler -- the current version calls SpaCy every step which is inefficient. If you do this once at the start of training you get a big speedup during BERT- based training (at least from what I have observed).

This might also help with Issue #11 

Let me know if this is helpful or if you want to move this to the not-public version of the code. 

Thanks,
Tom